### PR TITLE
OSIS-467 Delete of auditaleSerializableModel set flag to_delete to true

### DIFF
--- a/models/auditable_serializable_model.py
+++ b/models/auditable_serializable_model.py
@@ -29,8 +29,8 @@ from django.contrib import admin
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from osis_common.models.auditable_model import auditable_model_post_save, auditable_model_flag_delete
-from osis_common.models.serializable_model import serialize, serializable_model_post_save, \
-    serializable_model_post_delete, serializable_model_resend_messages_to_queue, wrap_serialization
+from osis_common.models.serializable_model import serializable_model_post_save,  serializable_model_post_delete,\
+    serializable_model_resend_messages_to_queue
 
 
 class AuditableSerializableQuerySet(models.QuerySet):
@@ -69,7 +69,7 @@ class AuditableSerializableModel(models.Model):
 
     def delete(self, *args, **kwargs):
         result = auditable_model_flag_delete(self)
-        serializable_model_post_delete(self)
+        serializable_model_post_delete(self, to_delete=True)
         return result
 
     def natural_key(self):

--- a/models/serializable_model.py
+++ b/models/serializable_model.py
@@ -251,7 +251,7 @@ def persist(structure):
         query_set = model_class.objects.filter(uuid=fields.get('uuid'))
         persisted_obj = query_set.first()
         if not persisted_obj:
-            obj_id = _make_insert(fields, model_class)
+            obj_id = _make_insert(fields, model_class.__bases__[0], model_class)
             if obj_id:
                 return obj_id
             else:
@@ -292,11 +292,11 @@ def _make_update(fields, model_class, persisted_obj, query_set):
     return persisted_obj.id
 
 
-def _make_insert(fields, model_class):
+def _make_insert(fields, super_class, model_class):
     kwargs = _build_kwargs(fields, model_class)
     del kwargs['id']
     obj = model_class(**kwargs)
-    super(SerializableModel, obj).save(force_insert=True)
+    super(super_class, obj).save(force_insert=True)
     obj_id = obj.id
     return obj_id
 

--- a/tests/models/test_auditable_serializable_model.py
+++ b/tests/models/test_auditable_serializable_model.py
@@ -1,0 +1,57 @@
+##############################################################################
+#
+#    OSIS stands for Open Student Information System. It's an application
+#    designed to manage the core business of higher education institutions,
+#    such as universities, faculties, institutes and professional schools.
+#    The core business involves the administration of students, teachers,
+#    courses, programs and so on.
+#
+#    Copyright (C) 2015-2017 Université catholique de Louvain (http://www.uclouvain.be)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of this license - GNU General Public License - is available
+#    at the root of the source code of this program.  If not,
+#    see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from unittest.mock import patch
+
+from django.test.testcases import TestCase
+from django.db.models.fields import CharField
+
+from osis_common.models.auditable_serializable_model import AuditableSerializableModel
+
+
+class AuditableModelWithUser(AuditableSerializableModel):
+    user = CharField(max_length=30, null=True)
+    name = CharField(max_length=30, unique=True)
+
+    def __str__(self):
+        return '{} - {} - {}'.format(self.name, self.user, self.uuid)
+
+
+class TestAuditableSerializableObject(TestCase):
+    def setUp(self):
+        self.auditable_instance = AuditableModelWithUser(user="User", name="Name")
+
+    @patch("osis_common.models.auditable_serializable_model.serializable_model_post_save", side_effect=None)
+    def test_save(self, mock_post_save):
+        self.auditable_instance.save()
+        self.assertTrue(mock_post_save.called)
+
+    @patch("osis_common.models.auditable_serializable_model.serializable_model_post_delete", side_effect=None)
+    def test_delete(self, mock_post_delete):
+        self.auditable_instance.save()
+        self.auditable_instance.delete()
+        self.assertTrue(mock_post_delete.called)
+        mock_post_delete.assert_called_once_with(self.auditable_instance, to_delete=True)
+        self.assertTrue(self.auditable_instance.deleted)


### PR DESCRIPTION
AuditableSerializableModel didn't set the flag to_delete to true
when sending the serialized instance to the queue.

OSIS-467