### PR TITLE
OSIS-472

### DIFF
--- a/tests/utils/test_datetime.py
+++ b/tests/utils/test_datetime.py
@@ -28,7 +28,6 @@ import factory
 import factory.fuzzy
 
 from django.test import TestCase
-from django.utils import timezone
 
 from osis_common.utils.datetime import get_tzinfo, strictly_ordered_dates, convert_datetime_to_date, \
     convert_date_to_datetime

--- a/tests/utils/test_enumerations.py
+++ b/tests/utils/test_enumerations.py
@@ -1,0 +1,38 @@
+##############################################################################
+#
+#    OSIS stands for Open Student Information System. It's an application
+#    designed to manage the core business of higher education institutions,
+#    such as universities, faculties, institutes and professional schools.
+#    The core business involves the administration of students, teachers,
+#    courses, programs and so on.
+#
+#    Copyright (C) 2015-2017 Université catholique de Louvain (http://www.uclouvain.be)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    A copy of this license - GNU General Public License - is available
+#    at the root of the source code of this program.  If not,
+#    see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from django.test import TestCase
+
+from osis_common.utils.enumerations import ChoiceEnum
+
+
+class TestEnumerations(TestCase):
+
+    def test_choice_enum(self):
+        class Enum(ChoiceEnum):
+            TEST = 'TESTE'
+
+        self.assertEquals(Enum.choices()[0], (Enum.TEST.value, Enum.TEST.value))
+

--- a/utils/enumerations.py
+++ b/utils/enumerations.py
@@ -1,0 +1,32 @@
+##############################################################################
+#
+#    OSIS stands for Open Student Information System. It's an application
+#    designed to manage the core business of higher education institutions,
+#    such as universities, faculties, institutes and professional schools.
+#    The core business involves the administration of students, teachers,
+#    courses, programs and so on.
+#
+#    Copyright (C) 2015-2017 Université catholique de Louvain (http://www.uclouvain.be)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of this license - GNU General Public License - is available
+#    at the root of the source code of this program.  If not,
+#    see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from enum import Enum
+
+
+class ChoiceEnum(Enum):
+    @classmethod
+    def choices(cls):
+        return tuple((x.value, x.value) for x in cls)


### PR DESCRIPTION
`ChoiceEnum` c'est une subclass de `Enum` qu'ajoute la fonction `choices` dans les enumerations, comme demandé par le modèle Django.