### PR TITLE
IUFC-163 Send update signal after processing message from queue

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,26 @@
+##############################################################################
+#
+#    OSIS stands for Open Student Information System. It's an application
+#    designed to manage the core business of higher education institutions,
+#    such as universities, faculties, institutes and professional schools.
+#    The core business involves the administration of students, teachers,
+#    courses, programs and so on.
+#
+#    Copyright (C) 2015-2018 Université catholique de Louvain (http://www.uclouvain.be)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of this license - GNU General Public License - is available
+#    at the root of the source code of this program.  If not,
+#    see http://www.gnu.org/licenses/.
+#
+##############################################################################
+default_app_config = 'osis_common.apps.OsisCommonConfig'

--- a/apps.py
+++ b/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class OsisCommonConfig(AppConfig):
     name = 'osis_common'
+
+    def ready(self):
+        from .signals import publisher

--- a/signals/publisher.py
+++ b/signals/publisher.py
@@ -1,0 +1,28 @@
+##############################################################################
+#
+#    OSIS stands for Open Student Information System. It's an application
+#    designed to manage the core business of higher education institutions,
+#    such as universities, faculties, institutes and professional schools.
+#    The core business involves the administration of students, teachers,
+#    courses, programs and so on.
+#
+#    Copyright (C) 2015-2018 Université catholique de Louvain (http://www.uclouvain.be)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of this license - GNU General Public License - is available
+#    at the root of the source code of this program.  If not,
+#    see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from django.dispatch import Signal
+
+post_update_from_queue = Signal(providing_args=["instance"])

--- a/tests/models/test_serializable_model.py
+++ b/tests/models/test_serializable_model.py
@@ -97,6 +97,7 @@ class TestSerializeObjectOnCommit(TransactionTestCase):
         self.assertTrue(mock_post_delete.called)
         mock_post_delete.assert_called_once_with(self.model_with_user, to_delete=True)
 
+
 if hasattr(settings, 'QUEUES') and settings.QUEUES:
     class TestMessageQueueCache(TransactionTestCase):
         def test_message_queue_cache_no_insert(self):


### PR DESCRIPTION
When receiving a new model instance from queue, post_save signal is sent but it is not the case when an instance is updated. It is therefore possible to create a signal and send after the queryset is updated (_make_update function).

Inform the ticket you are solving in this pull request: IUFC-163

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
