### PR TITLE
do not build_and_send if no receiver

### DIFF
--- a/messaging/send_message.py
+++ b/messaging/send_message.py
@@ -214,14 +214,15 @@ def send_messages(message_content, force_sending_outside_production=False, conne
         )
 
     for lang_code, receivers in __map_receivers_by_languages(receivers).items():
-        _build_and_send_message(
-            connected_user,
-            message_content,
-            receivers,
-            html_message_templates,
-            txt_message_templates,
-            lang_code
-        )
+        if receivers:
+            _build_and_send_message(
+                connected_user,
+                message_content,
+                receivers,
+                html_message_templates,
+                txt_message_templates,
+                lang_code
+            )
 
     return None
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -33,6 +33,7 @@ from base.tests.factories.person import PersonFactory
 from osis_common.messaging import mail_sender_classes
 from osis_common.messaging import send_message, message_config
 from osis_common.messaging.message_config import create_receiver, create_table, create_message_content
+from osis_common.messaging.send_message import send_messages
 from osis_common.models import message_history
 from osis_common.models.message_history import MessageHistory
 from osis_common.models.message_template import MessageTemplate
@@ -133,6 +134,16 @@ class MessagesTestCase(TestCase):
             connected_user=self.connected_user
         )
         self.assertIsNotNone(message_error, 'A message error should be sent')
+
+    @patch('osis_common.messaging.send_message._build_and_send_message')
+    @patch('osis_common.messaging.send_message._get_all_lang_templates')
+    def test_build_and_send_messages_called_once(self, mock_get_all_lang_templates, mock_build_and_send_message):
+        mock_get_all_lang_templates.return_value = 'template_html', 'template_txt'
+        receiver = PersonFactory()
+        receivers = [message_config.create_receiver(receiver.id, receiver.email, None)]
+        msg_content = message_config.create_message_content('template_html', 'template_txt', [], receivers, {}, {})
+        send_messages(msg_content)
+        self.assertEqual(mock_build_and_send_message.call_count, 1)
 
     def __make_receivers(self):
         receiver1 = create_receiver(1, 'receiver1@email.org', 'fr-BE')

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -135,7 +135,8 @@ class MessagesTestCase(TestCase):
 
     @patch('osis_common.messaging.send_message._build_and_send_message')
     @patch('osis_common.messaging.send_message._get_all_lang_templates')
-    def test_build_and_send_messages_called_once(self, mock_get_all_lang_templates, mock_build_and_send_message):
+    def test_build_and_send_messages_called_once_with_one_receiver(
+            self, mock_get_all_lang_templates, mock_build_and_send_message):
         mock_get_all_lang_templates.return_value = 'template_html', 'template_txt'
         receiver = PersonFactory()
         receivers = [message_config.create_receiver(receiver.id, receiver.email, None)]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -27,13 +27,11 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.test import TestCase
-from django.utils.translation import ugettext_lazy as _
 
 from base.tests.factories.person import PersonFactory
 from osis_common.messaging import mail_sender_classes
 from osis_common.messaging import send_message, message_config
 from osis_common.messaging.message_config import create_receiver, create_table, create_message_content
-from osis_common.messaging.send_message import send_messages
 from osis_common.models import message_history
 from osis_common.models.message_history import MessageHistory
 from osis_common.models.message_template import MessageTemplate
@@ -142,7 +140,7 @@ class MessagesTestCase(TestCase):
         receiver = PersonFactory()
         receivers = [message_config.create_receiver(receiver.id, receiver.email, None)]
         msg_content = message_config.create_message_content('template_html', 'template_txt', [], receivers, {}, {})
-        send_messages(msg_content)
+        send_message.send_messages(msg_content)
         self.assertEqual(mock_build_and_send_message.call_count, 1)
 
     def __make_receivers(self):


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
