### PR TITLE
Api PgmManagement Role returns {<INT>: [<STRING>]} , not {<STRING>: […

### DIFF
--- a/tests/ressources/person_roles_from_api.json
+++ b/tests/ressources/person_roles_from_api.json
@@ -8,10 +8,10 @@
       "program_manager": {
         "description": "Test reddot roles from api",
         "scope": [
-          {"acronym":  "PHYS1BA", "year": "2017"},
-          {"acronym":  "PHYS1BA", "year": "2018"},
-          {"acronym":  "BIOL1BA", "year": "2017"},
-          {"acronym":  "BIOL1BA", "year": "2018"}
+          {"acronym":  "PHYS1BA", "year": 2017},
+          {"acronym":  "PHYS1BA", "year": 2018},
+          {"acronym":  "BIOL1BA", "year": 2017},
+          {"acronym":  "BIOL1BA", "year": 2018}
         ]
       }
   }


### PR DESCRIPTION
…<STRING>]}

Inform the ticket you are solving in this pull request: OSIS-3616

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
