### PR TITLE
FIX osis-common OSIS-3621 : plantage quand le connected user n'a pas …

### DIFF
--- a/messaging/mail_sender_classes.py
+++ b/messaging/mail_sender_classes.py
@@ -29,7 +29,7 @@ import logging
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 from osis_common.models import message_history as message_history_mdl
 
@@ -114,7 +114,13 @@ class ConnectedUserMailSender(MasterMailSender):
     """
     def get_real_receivers_list(self):
         if self.connected_user:
-            return [self.connected_user.person.email]
+            if self.connected_user.person.email:
+                return [self.connected_user.person.email]
+            else:
+                logger.error('ConnectedUserMailSender class was used, but no connected_user email was given. '
+                             'Email will be sent to the COMMON_EMAIL_RECEIVER (from settings) instead.')
+                return [settings.COMMON_EMAIL_RECEIVER]
+
         else:
             logger.error('ConnectedUserMailSender class was used, but no connected_user was given. '
                          'Email will be sent to the COMMON_EMAIL_RECEIVER (from settings) instead.')
@@ -149,8 +155,8 @@ def add_testing_information_to_contents(mail):
         "This is a test email sent from OSIS, only sent to {new_dest_address}. "
         "Planned receivers were : {receivers_addresses}."
     ).format(
-        new_dest_address=', '.join(mail.real_receivers_list),
-        receivers_addresses=', '.join(mail.original_receivers_list)
+        new_dest_address=', '.join(filter(None, mail.real_receivers_list)),
+        receivers_addresses=', '.join(filter(None, mail.original_receivers_list))
     )
 
     mail.kwargs['message'] = "{testing_informations} \n {original_message}".format(

--- a/messaging/mail_sender_classes.py
+++ b/messaging/mail_sender_classes.py
@@ -29,7 +29,7 @@ import logging
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from osis_common.models import message_history as message_history_mdl
 

--- a/messaging/mail_sender_classes.py
+++ b/messaging/mail_sender_classes.py
@@ -113,16 +113,11 @@ class ConnectedUserMailSender(MasterMailSender):
     Send email to the email address of the connected user
     """
     def get_real_receivers_list(self):
-        if self.connected_user:
-            if self.connected_user.person.email:
-                return [self.connected_user.person.email]
-            else:
-                logger.error('ConnectedUserMailSender class was used, but no connected_user email was given. '
-                             'Email will be sent to the COMMON_EMAIL_RECEIVER (from settings) instead.')
-                return [settings.COMMON_EMAIL_RECEIVER]
-
+        if self.connected_user and self.connected_user.person.email:
+            return [self.connected_user.person.email]
         else:
-            logger.error('ConnectedUserMailSender class was used, but no connected_user was given. '
+            missing_field = 'connected_user' + (' email' if self.connected_user else '')
+            logger.error('ConnectedUserMailSender class was used, but no ' + missing_field + ' was given. '
                          'Email will be sent to the COMMON_EMAIL_RECEIVER (from settings) instead.')
             return [settings.COMMON_EMAIL_RECEIVER]
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -35,7 +35,7 @@ from osis_common.messaging.message_config import create_receiver, create_table, 
 from osis_common.models import message_history
 from osis_common.models.message_history import MessageHistory
 from osis_common.models.message_template import MessageTemplate
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MessagesTestCase(TestCase):


### PR DESCRIPTION
…d'email

Erreur balancée par le console 'TypeError sequence item 0:expected str instance, NoneType found'.  L'erreur arrive dans la méthode add_testing_information_to_contents
Pour résoudre :
- on fait un filter sur None dans la liste des emails dans la fonction
- par ailleurs on affiche un error console si le connected_user n'a pas d'email

Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
