### PR TITLE
OSIS-5443 : Correction d'une traducation 'cote de présence' devient '…

### DIFF
--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -110,7 +110,7 @@ msgstr "Note"
 
 #, python-brace-format
 msgid "Score legend: {score} (0=Score of presence)"
-msgstr "Légende pour le champ 'Note chiffrée': {score} (0=Cote de présence)"
+msgstr "Légende pour le champ 'Note chiffrée': {score} (0=Note de présence)"
 
 msgid "Score sheet"
 msgstr "Feuille de notes"

--- a/tests/document/test_paper_sheet.py
+++ b/tests/document/test_paper_sheet.py
@@ -146,7 +146,7 @@ class TestPaperSheet(TestCase):
             paragraph.text,
             (
                 """<para> Légende pour le champ 'Justification': A=Absent, T=Tricherie<br/>Légende pour le champ """
-                """'Note chiffrée': 0 - 20 (0=Cote de présence)<br/><font color=red>Les notes décimales sont """
+                """'Note chiffrée': 0 - 20 (0=Note de présence)<br/><font color=red>Les notes décimales sont """
                 """autorisées pour ce cours</font><br/><span backColor=#dff0d8>&nbsp; Inscrit tardivement &nbsp;"""
                 """""""</span> - <span backColor=#f2dede>&nbsp; Désinscrit tardivement &nbsp;</span><br/> """
                 """Conformément aux articles 104, 109 et 111 RGEE (Règlement général des études et des examens) """
@@ -164,7 +164,7 @@ class TestPaperSheet(TestCase):
             paragraph.text,
             (
                 """<para> Légende pour le champ 'Justification': A=Absent, T=Tricherie<br/>Légende pour le champ """
-                """'Note chiffrée': 0 - 20 (0=Cote de présence)<br/><font color=red>Attention : décimales non """
+                """'Note chiffrée': 0 - 20 (0=Note de présence)<br/><font color=red>Attention : décimales non """
                 """autorisées pour ce cours</font><br/><span backColor=#dff0d8>&nbsp; Inscrit tardivement &nbsp;"""
                 """""""</span> - <span backColor=#f2dede>&nbsp; Désinscrit tardivement &nbsp;</span><br/> """
                 """Conformément aux articles 104, 109 et 111 RGEE (Règlement général des études et des examens) """


### PR DESCRIPTION
…note de présence'

Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
