### PR TITLE
OSIS-5645 Upgrade du persist de serializable_model

### DIFF
--- a/models/serializable_model.py
+++ b/models/serializable_model.py
@@ -215,7 +215,10 @@ def unwrap_serialization(wrapped_serialization):
 
 
 def persist(structure):
-    model_class = apps.get_model(structure.get('model'))
+    try:
+        model_class = apps.get_model(structure.get('model'))
+    except LookupError:
+        return
     if structure:
         fields = structure.get('fields')
         for field_name, value in fields.items():

--- a/tests/models/test_serializable_model.py
+++ b/tests/models/test_serializable_model.py
@@ -123,7 +123,7 @@ class TestPersist(TestCase):
             ModelWithUser
         )
 
-    def test_persist_case_with_model_not_serializable(self):
+    def test_persist_case_with_model_not_existing(self):
         structure_serialized = serialize(self.model_with_user, to_delete=False)
         structure_serialized["model"] = "reference.Test"
         result = persist(structure_serialized)

--- a/tests/models/test_serializable_model.py
+++ b/tests/models/test_serializable_model.py
@@ -123,6 +123,12 @@ class TestPersist(TestCase):
             ModelWithUser
         )
 
+    def test_persist_case_with_model_not_serializable(self):
+        structure_serialized = serialize(self.model_with_user, to_delete=False)
+        structure_serialized["model"] = "reference.Test"
+        result = persist(structure_serialized)
+        self.assertEqual(result, None)
+
     @patch("osis_common.models.serializable_model._make_upsert", side_effect=None)
     def test_persist_case_update_existing(self, mock_make_upsert):
         # Save instance in order to have UUID on database


### PR DESCRIPTION
- Add try except pour les cas où un modèle n'existerait pas lors du persist pour ignorer le modèle concerné.

Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
