### PR TITLE
OSIS-1104 add transaction id on command interface

### DIFF
--- a/ddd/interface.py
+++ b/ddd/interface.py
@@ -1,9 +1,13 @@
 import abc
+import uuid
 from typing import List, Optional, Callable, Union
 
+import attr
 
+
+@attr.s(frozen=True, slots=True)
 class CommandRequest(abc.ABC):
-    pass
+    transaction_id = attr.ib(init=False, type=uuid.UUID, default=attr.Factory(uuid.uuid4))
 
 
 class BusinessException(Exception):

--- a/ddd/interface.py
+++ b/ddd/interface.py
@@ -7,7 +7,7 @@ import attr
 
 @attr.s(frozen=True, slots=True)
 class CommandRequest(abc.ABC):
-    transaction_id = attr.ib(init=False, type=uuid.UUID, default=attr.Factory(uuid.uuid4))
+    transaction_id = attr.ib(init=False, type=uuid.UUID, default=attr.Factory(uuid.uuid4), eq=False)
 
 
 class BusinessException(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django-ckeditor==5.7.1 # Version 5.2.2 to support PasteFromWord into CKEditor
 XlsxWriter==0.9.3
 voluptuous==0.9.3
 weasyprint==0.42.3
+attrs==19.3.0


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
