### PR TITLE
Osis 7895 introuce version id on root entity

### DIFF
--- a/ddd/interface.py
+++ b/ddd/interface.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import List, Optional, Callable, Union
 
 import attr
+from django.utils.translation import gettext_lazy as _
 
 
 @attr.s(frozen=True, slots=True)
@@ -41,6 +42,12 @@ class BusinessExceptions(BusinessException):
         self.messages = messages
 
 
+class VersionMismatchException(Exception):
+    def __init__(self, **kwargs):
+        self.message = _('Error occured. Please retry.')
+        super().__init__(**kwargs)
+
+
 class ValueObject(abc.ABC):
     def __eq__(self, other):
         raise NotImplementedError
@@ -68,7 +75,9 @@ class Entity(abc.ABC):
 
 
 class RootEntity(Entity):
-    pass
+    def __init__(self, *args, version_id: int, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.version_id = version_id
 
 
 class DTO:

--- a/ddd/interface.py
+++ b/ddd/interface.py
@@ -74,10 +74,9 @@ class Entity(abc.ABC):
         return hash(self.entity_id)
 
 
+@attr.s(eq=False, hash=False)
 class RootEntity(Entity):
-    def __init__(self, *args, version_id: int, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.version_id = version_id
+    version_id = attr.ib(type=int, default=0, eq=False, repr=False, kw_only=True)
 
 
 class DTO:

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -50,6 +50,9 @@ msgstr ""
 msgid "Enrolled lately"
 msgstr ""
 
+msgid "Error occured. Please retry."
+msgstr ""
+
 msgid "False"
 msgstr ""
 

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -51,6 +51,9 @@ msgstr "Courriel"
 msgid "Enrolled lately"
 msgstr "Inscrit tardivement"
 
+msgid "Error occured. Please retry."
+msgstr "Une erreur inattendue est survenue. Veuillez réessayer."
+
 msgid "False"
 msgstr "Faux"
 


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
