### PR TITLE
Fix import of DjangoModelFactory

### DIFF
--- a/tests/factories/application_notice.py
+++ b/tests/factories/application_notice.py
@@ -29,7 +29,7 @@ import factory.fuzzy
 from django.utils import timezone
 
 
-class ApplicationNoticeFactory(factory.DjangoModelFactory):
+class ApplicationNoticeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'osis_common.ApplicationNotice'
 

--- a/tests/factories/document_file.py
+++ b/tests/factories/document_file.py
@@ -31,7 +31,7 @@ from osis_common.models.enum import storage_duration
 CONTENT_TYPE_LIST = [x for (x, y) in CONTENT_TYPE_CHOICES]
 
 
-class DocumentFileFactory(factory.DjangoModelFactory):
+class DocumentFileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'osis_common.DocumentFile'
 


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
