### PR TITLE
OSIS-8371: When persist base_person via SerializableModel, use global…

### DIFF
--- a/models/serializable_model.py
+++ b/models/serializable_model.py
@@ -224,7 +224,14 @@ def persist(structure):
         for field_name, value in fields.items():
             if isinstance(value, dict):
                 fields[field_name] = persist(value)
-        query_set = model_class.objects.filter(uuid=fields.get('uuid'))
+
+        lookup_kwargs = {}
+        if structure.get('model') == "base.Person":
+            lookup_kwargs['global_id'] = fields.get('global_id')
+        else:
+            lookup_kwargs['uuid'] = fields.get('uuid')
+
+        query_set = model_class.objects.filter(**lookup_kwargs)
         persisted_obj = query_set.first()
         super_class = model_class.__bases__[0]
         if not persisted_obj:


### PR DESCRIPTION
…_id instead of uuid

Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
