### PR TITLE
OSIS-9158 correction erreur instanciation Event via cattrs

### DIFF
--- a/management/commands/inbox_worker.py
+++ b/management/commands/inbox_worker.py
@@ -67,6 +67,7 @@ class InboxThreadWorker(ConsumerThreadWorkerStrategy):
                 logger.info(f"{self._logger_prefix_message()}: Process {len(unprocessed_events)} events...")
 
             for unprocessed_event in unprocessed_events:
+                event_instance = None
                 event_name = unprocessed_event.event_name
                 try:
                     event_instance = self._build_event_instance(unprocessed_event)


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
