### PR TITLE
[To QA] prevent add handlers if deliberation not in INSTALLED_APPS

### DIFF
--- a/utils/inbox_outbox.py
+++ b/utils/inbox_outbox.py
@@ -89,6 +89,8 @@ class HandlersPerContextFactory:
         consumers_list = {}
         handlers_path = glob.glob("infrastructure/*/handlers.py", recursive=True)
         for handler_path in handlers_path:
+            if 'deliberation' in handlers_path and 'deliberation' not in settings.INSTALLED_APPS:
+                continue
             with contextlib.suppress(AttributeError):
                 handler_module = HandlersPerContextFactory.__import_file('handler_module', handler_path)
                 if handler_module.EVENT_HANDLERS:


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
