### PR TITLE
OSIS-9570: Ensure order by creation_date for batch

### DIFF
--- a/utils/inbox_outbox.py
+++ b/utils/inbox_outbox.py
@@ -132,7 +132,7 @@ class InboxConsumer:
             with transaction.atomic():
                 unprocessed_events_in_batch = self.inbox_model.objects.select_for_update().filter(
                     pk__in=unprocessed_events_qs.values_list('pk', flat=True)[:batch_size]
-                )
+                ).order_by('creation_date')
                 logger.info(f"{self._logger_prefix_message()}: Process {len(unprocessed_events_in_batch)} events...")
                 for unprocessed_event in unprocessed_events_in_batch:
                     processed_event = self.consume(unprocessed_event)


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
