### PR TITLE
[To QA] OSIS-9989 mark_as_dead_letter if event not in EventHandlers definition

### DIFF
--- a/utils/inbox_outbox.py
+++ b/utils/inbox_outbox.py
@@ -164,7 +164,9 @@ class InboxConsumer:
             unprocessed_event.mark_as_processed()
         except EventClassNotFound as e:
             logger.warning(e.message)
-            unprocessed_event.mark_as_error('\n'.join(traceback.format_exception(e)))
+            # mark as dead letter pour éviter de bloquer le processus de consommation pour une raison autre que métier
+            # Si l'event n'est plus dans les handlers, pas nécessaire de réessayer 15 fois (peut-être obsolète)
+            unprocessed_event.mark_as_dead_letter('\n'.join(traceback.format_exception(e)))
         except Exception as e:
             logger.exception(
                 f"{self._logger_prefix_message()}: Cannot process {event_name} event ({event_instance})",


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
