### PR TITLE
[hotfix/OSIS-10334 => MASTER] Prevent inter-consumer blocking

### DIFF
--- a/utils/inbox_outbox.py
+++ b/utils/inbox_outbox.py
@@ -421,7 +421,9 @@ class InboxConsumer:
             failed_event = None
             try:
                 with transaction.atomic():
-                    unprocessed_events_in_batch = self.inbox_model.objects.select_for_update().filter(
+                    unprocessed_events_in_batch = self.inbox_model.objects.select_for_update(
+                        skip_locked=True  # Prevent blocking inter-consumer
+                    ).filter(
                         pk__in=unprocessed_events_ids
                     ).order_by('creation_date')
 


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
