### PR TITLE
Move dj-control-room out of osis_common

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ django-waffle==5.0.0
 django-htmx==1.27.0
 django-sass==1.1.0
 django-ckeditor==6.6.1  # Next version show security alert (maybe update ckeditor version 5)
-dj-control-room[all]==1.2.0
 
 # Minify / Compress CSS/JS
 django-pipeline==4.1.0


### PR DESCRIPTION
Inform the ticket you are solving in this pull request: #

WARNING :: Ne jamais supprimer/modifier le comportement d'une fonction existante. Il faut en créer une nouvelle, et mettre l'ancienne en "deprecated". Elle devra être supprimée lors d'une prochaine version d'osis-common.
